### PR TITLE
Add `delete()` method to the `ThreadsClient`

### DIFF
--- a/docs/basic-client.md
+++ b/docs/basic-client.md
@@ -142,6 +142,26 @@ $post = Threads::token($token)->single(id: $id)->json();
 //]
 ```
 
+## Delete Post
+
+You can delete a specific post (Threads media) using its ID.
+
+```php
+use Revolution\Threads\Facades\Threads;
+
+$idToDelete = 'your_post_id_here'; // Replace with the actual ID of the post to delete
+
+$response = Threads::token($token)->delete(id: $idToDelete);
+
+if ($response->successful() && $response->json('success')) {
+    // Post was successfully deleted
+    echo "Post deleted successfully.";
+} else {
+    // Handle error
+    echo "Failed to delete post: " . $response->body();
+}
+```
+
 ## Macroable
 
 If you need other methods you can add any method using the macro feature.

--- a/src/Contracts/Factory.php
+++ b/src/Contracts/Factory.php
@@ -85,6 +85,13 @@ interface Factory
     public function repost(string $id): Response;
 
     /**
+     * Delete Threads Media.
+     *
+     * @return Response{success: bool}
+     */
+    public function delete(string $id): Response;
+
+    /**
      * Publishing status.
      *
      * @return Response{status: string, id: string, error_message?: string}

--- a/src/Socialite/ThreadsProvider.php
+++ b/src/Socialite/ThreadsProvider.php
@@ -18,6 +18,7 @@ class ThreadsProvider extends AbstractProvider implements ProviderInterface
     protected $scopes = [
         'threads_basic',
         'threads_content_publish',
+        'threads_delete',
     ];
 
     protected string $endpoint = 'https://graph.threads.net/';

--- a/src/ThreadsClient.php
+++ b/src/ThreadsClient.php
@@ -190,6 +190,12 @@ class ThreadsClient implements Factory
             ->post($id.'/repost');
     }
 
+    public function delete(string $id): Response
+    {
+        return $this->http()
+            ->delete($id);
+    }
+
     public function status(string $id, ?array $fields = null): Response
     {
         $fields ??= [

--- a/tests/Feature/Client/ClientTest.php
+++ b/tests/Feature/Client/ClientTest.php
@@ -171,6 +171,32 @@ class ClientTest extends TestCase
 
         $this->assertIsArray($res);
     }
+
+    public function test_repost()
+    {
+        Http::fakeSequence()
+            ->push(['id' => 'repost_id'])
+            ->whenEmpty(Http::response());
+
+        $id = Threads::token('token')
+            ->repost(id: 'post_id')
+            ->json('id');
+
+        $this->assertSame('repost_id', $id);
+    }
+
+    public function test_delete()
+    {
+        Http::fakeSequence()
+            ->push(['success' => true])
+            ->whenEmpty(Http::response());
+
+        $success = Threads::token('token')
+            ->delete(id: 'post_id')
+            ->json('success');
+
+        $this->assertTrue($success);
+    }
 }
 
 class TestUser extends Model

--- a/tests/Feature/Socialite/SocialiteTest.php
+++ b/tests/Feature/Socialite/SocialiteTest.php
@@ -59,7 +59,7 @@ class SocialiteTest extends TestCase
         $this->assertStringStartsWith('https://threads.net/oauth/authorize', $url);
         $this->assertStringContainsString('client_id=client_id', $url);
         $this->assertStringContainsString('redirect_uri=redirect', $url);
-        $this->assertStringContainsString('scope=threads_basic%2Cthreads_content_publish', $url);
+        $this->assertStringContainsString('scope=threads_basic%2Cthreads_content_publish%2Cthreads_delete', $url);
         $this->assertStringContainsString('response_type=code', $url);
     }
 
@@ -74,7 +74,8 @@ class SocialiteTest extends TestCase
         $response = $provider->redirect();
 
         $url = $response->getTargetUrl();
-        $this->assertStringContainsString('scope=threads_basic%2Cthreads_content_publish%2Cthreads_manage_insights', $url);
+        // After merging with default 'threads_delete' and sorting
+        $this->assertStringContainsString('scope=threads_basic%2Cthreads_content_publish%2Cthreads_delete%2Cthreads_manage_insights', $url);
     }
 
     public function test_get_auth_url_returns_correct_url()
@@ -222,7 +223,7 @@ class SocialiteTest extends TestCase
         $request = Request::create('foo');
         $provider = new ThreadsProvider($request, 'client_id', 'client_secret', 'redirect');
 
-        $this->assertEquals(['threads_basic', 'threads_content_publish'], $provider->getScopes());
+        $this->assertEquals(['threads_basic', 'threads_content_publish', 'threads_delete'], $provider->getScopes());
     }
 
     public function test_provider_with_custom_scopes()
@@ -231,8 +232,12 @@ class SocialiteTest extends TestCase
         $provider = new ThreadsProvider($request, 'client_id', 'client_secret', 'redirect');
 
         $provider->scopes(['threads_basic', 'threads_content_publish', 'threads_manage_insights']);
-
-        $this->assertEquals(['threads_basic', 'threads_content_publish', 'threads_manage_insights'], $provider->getScopes());
+        // Expect merged and sorted scopes
+        $expectedScopes = ['threads_basic', 'threads_content_publish', 'threads_delete', 'threads_manage_insights'];
+        sort($expectedScopes); // Ensure order for comparison if getScopes() also sorts, though it usually doesn't for raw array.
+        $actualScopes = $provider->getScopes();
+        sort($actualScopes);
+        $this->assertEquals($expectedScopes, $actualScopes);
     }
 
     public function test_user_profile_request_uses_bearer_token()
@@ -283,7 +288,8 @@ class SocialiteTest extends TestCase
         $response = $provider->redirect();
 
         $url = $response->getTargetUrl();
-        $this->assertStringContainsString('scope=threads_basic%2Cthreads_content_publish%2Cthreads_manage_insights', $url);
+        // After merging with default 'threads_delete' and sorting
+        $this->assertStringContainsString('scope=threads_basic%2Cthreads_content_publish%2Cthreads_delete%2Cthreads_manage_insights', $url);
     }
 
     public function test_get_user_by_token_method()


### PR DESCRIPTION
This commit introduces the `delete()` method to the `ThreadsClient`, allowing you to delete Threads posts.

The following changes were made:
- Added the `delete()` method to `src/ThreadsClient.php`.
- Updated the `src/Contracts/Factory.php` interface to include the `delete()` method.
- Added unit tests for both the new `delete()` method and the existing `repost()` method in `tests/Feature/Client/ClientTest.php`.
- Added documentation for the `delete()` method in `docs/basic-client.md`.

----

This commit addresses your feedback:
- Renames the `$postId` parameter to `$id` in the `delete()` method across `src/ThreadsClient.php`, `src/Contracts/Factory.php`, relevant tests, and documentation.
- Adds `threads_delete` to the default scopes in `src/Socialite/ThreadsProvider.php` to ensure the necessary permission for deleting posts is requested by default.

----

Fix: Update Socialite test for threads_delete scope

This commit fixes the failing Socialite test by updating the expected scopes to include `threads_delete`.

The `threads_delete` scope was added to the default scopes in a previous commit, which caused the test to fail. This commit updates the test to expect the new default scope.